### PR TITLE
Remove `set term`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -31,9 +31,6 @@ if has('gui_running')
     set macmeta
     set fuoptions=maxvert,maxhorz
   endif
-else
-  " Set terminal type.
-  set term=$TERM
 endif
 
 " Prevent Vim from clobbering the scrollback buffer.


### PR DESCRIPTION
This setting is obsolete in NeoVim and default in vim/macvim.

@tjdunklee and @mckennedy, can you test that this doesn't break your setup?